### PR TITLE
addressing `planemo: Unsupported special dependency :python`

### DIFF
--- a/planemo.rb
+++ b/planemo.rb
@@ -13,7 +13,8 @@ class Planemo < Formula
 
   option "without-completions", "Disable bash/zsh completions"
 
-  depends_on :python if MacOS.version <= :snow_leopard
+  #depends_on :python if MacOS.version <= :snow_leopard
+  depends_on "python@2" if MacOS.version <= :snow_leopard
   depends_on "libxml2"  # For --xsd and --shed_lint
   depends_on "libyaml"
   depends_on "openssl"


### PR DESCRIPTION
I addressed the

> `planemo: Unsupported special dependency :python`

message received when I tried

> `brew tap galaxyproject/tap`

as done in [https://github.com/GRASS-GIS/homebrew-grass-dev/commit/668cc43ffac545851b93c7ae2ee3f86c2ef74afe](https://github.com/GRASS-GIS/homebrew-grass-dev/commit/668cc43ffac545851b93c7ae2ee3f86c2ef74afe)

so that I could `brew install planemo`.

If this is a sensible way to do so, please consider merging this PR.  Otherwise, could you please suggest to me how to address the issue?